### PR TITLE
Fix calibration menu labels and redundant camera start

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -39,9 +39,6 @@ void MainWindow::setupUi() {
     createMenus();
 
     cameraController = new CameraController(this);
-
-    // запускаем по умолчанию камеру 0
-    cameraController->startCamera(0);
 }
 
 
@@ -53,8 +50,8 @@ void MainWindow::createMenus() {
     QMenu *calibrationMenu = menuBar->addMenu("Режимы");
 
     actionVideoFlowSet = new QAction("Настроить параметры видео потока", this);
-    actionInternalCalibration = new QAction("Внешняя калибровка", this);
-    actionExternalCalibration = new QAction("Внутренняя калибровка", this);
+    actionInternalCalibration = new QAction("Внутренняя калибровка", this);
+    actionExternalCalibration = new QAction("Внешняя калибровка", this);
 
     calibrationMenu->addAction(actionVideoFlowSet);
     calibrationMenu->addAction(actionInternalCalibration);


### PR DESCRIPTION
## Summary
- Correct internal and external calibration menu labels
- Prevent double initialization by removing extra camera start call

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68960f6526b08333bab8d06ecc3d3d23